### PR TITLE
Add truncateLargeValues tests

### DIFF
--- a/engine/src/utils/file_utils.test.ts
+++ b/engine/src/utils/file_utils.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { truncateLargeValues } from './file_utils.js';
+
+// Test long string truncation
+
+describe('truncateLargeValues', () => {
+    it('truncates long strings over 2000 characters', () => {
+        const longStr = 'x'.repeat(2100);
+        const result = truncateLargeValues(longStr);
+        expect(result.length).toBeLessThan(longStr.length);
+        expect(result).toContain('[100 characters removed]');
+        expect(result.startsWith(longStr.slice(0, 1000))).toBe(true);
+        expect(result.endsWith(longStr.slice(-1000))).toBe(true);
+    });
+
+    it('truncates base64 image data strings', () => {
+        const prefix = 'data:image/png;base64,';
+        const base64 = prefix + 'A'.repeat(200);
+        const result = truncateLargeValues(base64);
+        expect(result.startsWith(prefix)).toBe(true);
+        expect(result.length).toBeLessThan(base64.length);
+        expect(result).toContain('characters removed');
+    });
+});


### PR DESCRIPTION
## Summary
- add initial Vitest file for truncateLargeValues utility
- verify long string truncation and base64 handling

## Testing
- `npm test`
- `npm run lint:fix` *(fails: 89 errors)*
- `npm run build:ci`


------
https://chatgpt.com/codex/tasks/task_e_68698edb3f90832aa802c66cb7e0c7eb