### PR TITLE
Fix CI docker-compose command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build and spin up Docker environment
         run: |
-          docker-compose up --build -d
+          docker compose up --build -d
       - name: Wait for services to be ready (adjust as needed)
         run: sleep 60 # Give services time to start up
       - name: Run smoke tests
@@ -73,4 +73,4 @@ jobs:
         run: echo "Running smoke tests..." # Replace with actual smoke test command
       - name: Tear down Docker environment
         if: always()
-        run: docker-compose down
+        run: docker compose down


### PR DESCRIPTION
## Summary
- fix GitHub Actions workflow step using `docker compose` instead of `docker-compose`

## Testing
- `npm run lint:fix`
- `npm run build:ci`


------
https://chatgpt.com/codex/tasks/task_e_686a04f5d9c8832ab62bef07e48b3a36